### PR TITLE
QOL Improvments

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - Highly configurable, and easy to configure!
 - Easy to translate via a Config.Language!
 - Inventory system built into the ranch!
+- Export API for other scripts to interact with this one!
 
 # How it works
 - Admins can make a ranch by entering the command, they will be greeted with a menu to name the ranch, insert the ranches radius, and the owners static id!
@@ -38,4 +39,16 @@
 - This is a massive project there is most likely oversights if you have any suggestions or bugs report them asap!
 - Ranch names can not have spaces in them currently!
 - To delete ranches you will currently have to delete them manually from the database!
-- Make sure admins trying to create ranches thier user group is admin or whatever you set the group to in the config!
+- Make sure to set yourself admin in the config.lua by adding your steam id where it asks for it!
+
+## API
+
+### Check if player owns a ranch!
+- To check if a player owns a ranch you can use
+```
+local _source = source
+local Character = VORPcore.getUser(_source).getUsedCharacter
+local result = exports['bcc-ranch']:CheckIfRanchIsOwned(Character.charIdentifier)
+```
+- This Api Is Server Side Only result will be true if the player owns a ranch false if they do not
+- You will need to pass the character id so you will have to have vorp core

--- a/client/MainRanch.lua
+++ b/client/MainRanch.lua
@@ -3,6 +3,8 @@ InMission = false
 RegisterNetEvent('vorp:SelectedCharacter')
 AddEventHandler('vorp:SelectedCharacter', function()
     Wait(7000)
+    local player = GetPlayerServerId(tonumber(PlayerId())) --credit vorp_admin
+    TriggerServerEvent("bcc-ranch:getPlayersInfo", player) --credit vorp_admin
     TriggerServerEvent('bcc-ranch:CheckIfRanchIsOwned')
 end)
 

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -28,3 +28,15 @@ end
 function relationshipsetup(ped, relint) --ped and player relationship setter, rail int is 1-5 1 being friend 5 being hate
   SetRelationshipBetweenGroups(relint, GetPedRelationshipGroupHash(ped), joaat('PLAYER'))
 end
+
+function GetPlayers()
+  TriggerServerEvent("bcc-ranch:GetPlayers")
+  local playersData = {}
+  RegisterNetEvent("bcc-ranch:SendPlayers", function(result)
+    playersData = result
+  end)
+  while next(playersData) == nil do
+    Wait(10)
+  end
+  return playersData
+end

--- a/client/menusetup/ranchcreation.lua
+++ b/client/menusetup/ranchcreation.lua
@@ -14,16 +14,21 @@ end)
 
 ------ Creating Ranch Menu ------
 RegisterNetEvent('bcc-ranch:CreateRanchmenu', function()
-    local ranchname, ranchradius, staticid
+    CreateRanchMen()
+end)
+
+local charid
+function CreateRanchMen()
+    local ranchname, ranchradius
     local coords = GetEntityCoords(PlayerPedId())
     Inmenu = true
     TriggerEvent('bcc-ranch:MenuClose')
     MenuData.CloseAll()
     
     local elements = {
+        { label = Config.Language.StaticId, value = 'staticid', desc = Config.Language.StaticId_desc },
         { label = Config.Language.NameRanch, value = 'nameranch', desc = Config.Language.NameRanch_desc },
         { label = Config.Language.RanchRadiusLimit, value = 'radiuslimit', desc = Config.Language.RanchRadiusLimit_desc },
-        { label = Config.Language.StaticId, value = 'staticid', desc = Config.Language.StaticId_desc },
         { label = Config.Language.Confirm, value = 'confirm', desc = Config.Language.Confirm_desc }
     }
 
@@ -38,7 +43,9 @@ RegisterNetEvent('bcc-ranch:CreateRanchmenu', function()
                 _G[data.trigger]()
             end
 
-            if data.current.value == 'nameranch' then
+            if data.current.value == 'staticid' then
+                PlayerList()
+            elseif data.current.value == 'nameranch' then
                 local myInput = {
                     type = "enableinput", -- don't touch
                     inputType = "input", -- input type
@@ -84,32 +91,50 @@ RegisterNetEvent('bcc-ranch:CreateRanchmenu', function()
                     end
                 end)
 
-            elseif data.current.value == 'staticid' then
-                local myInput = {
-                    type = "enableinput", -- don't touch
-                    inputType = "input", -- input type
-                    button = Config.Language.Confirm, -- button name
-                    placeholder = Config.Language.StaticId, -- placeholder name
-                    style = "block", -- don't touch
-                    attributes = {
-                        inputHeader = "", -- header
-                        type = "number", -- inputype text, number,date,textarea ETC
-                        pattern = "[0-9]", --  only numbers "[0-9]" | for letters only "[A-Za-z]+" 
-                        title = Config.Language.InvalidInput, -- if input doesnt match show this message
-                        style = "border-radius: 10px; background-color: ; border:none;"-- style 
-                    }
-                }
-                TriggerEvent("vorpinputs:advancedInput", json.encode(myInput), function(result)
-                    if tonumber(result) > 0 then
-                        staticid = tonumber(result)
-                    else
-                        VORPcore.NotifyRightTip(Config.Language.InvalidInput, 4000)
-                    end
-                end)
-
             elseif data.current.value == 'confirm' then
-                TriggerServerEvent('bcc-ranch:InsertCreatedRanchIntoDB', ranchname, ranchradius, staticid, coords)
+                TriggerServerEvent('bcc-ranch:InsertCreatedRanchIntoDB', ranchname, ranchradius, charid, coords)
+                charid = nil
                 MenuData.CloseAll()
             end
         end)
-end)
+end
+
+--------- Show the player list credit to vorp admin for this
+function PlayerList()
+    MenuData.CloseAll()
+    local elements = {}
+    local players = GetPlayers()
+
+    table.sort(players, function(a, b)
+        return a.serverId < b.serverId
+    end)
+
+    for k, playersInfo in pairs(players) do
+        elements[#elements + 1] = {
+            label = playersInfo.PlayerName .. "<br> Character Static ID: " .. playersInfo.staticid,
+            value = "players" .. k,
+            desc = "Give Player the Ranch? " .. "<span style=color:MediumSeaGreen;> ",
+            info = playersInfo
+        }
+    end
+
+    MenuData.Open('default', GetCurrentResourceName(), 'menuapi',
+        {
+            title      = Config.Language.StaticId,
+            subtext    = Config.Language.StaticId_desc,
+            align      = 'top-left',
+            elements   = elements,
+            lastmenu   = 'CreateRanchMen',
+            itemHeight = "4vh",
+        },
+        function(data)
+            if data.current == 'backup' then
+                _G[data.trigger]()
+            end
+            if data.current.value then
+                charid = data.current.info.staticid
+                VORPcore.NotifyRightTip(Config.Language.OwnerSet, 4000)
+                CreateRanchMen()
+            end
+        end)
+end

--- a/config.lua
+++ b/config.lua
@@ -126,14 +126,22 @@ Config.SaleLocations = {
     {
         LocationName = 'Sale Area 1', --this will be the name of the blip
         Coords = {x = -281.72, y = 697.67, z = 113.49}, --the coords the player will have to go to
-    },
+    }, --to add more just copy this table paste and change what you want
     {
         LocationName = 'Sale Area 2',
         Coords = {x = -239.39, y = 710.95, z = 113.29},
     },
 }
 
-Config.AdminGroupName = 'admin' --Make this the name of the user group that will handle creaing ranches deleting ranches etc
+---------- Admin Configuration (Anyone listed here will be able to create and delete ranches!) -----------
+Config.AdminSteamIds = {
+    {
+        steamid = 'steam:11000013707db22', --insert players steam id
+    }, --to add more just copy this table paste and change id
+    {
+        steamid = 'id2'
+    }
+}
 Config.CreateRanchCommand = 'createranch' --name of the command used to create ranches!
 
 ------------- Translate Here ------------------------
@@ -146,8 +154,8 @@ Config.Language = {
     RanchRadiusLimit_desc = 'Will limit how far away the owner can set things like chore locations',
     CreateRanchTitle = 'Create a Ranch!',
     InvalidInput = 'Invalid Input',
-    StaticId = 'Owners Static Id',
-    StaticId_desc = 'The Owner of the ranchs static id',
+    StaticId = 'Set Owner',
+    StaticId_desc = 'Assign The Ranch Owner',
     OpenRanchMenu = 'Press "G" To Open Ranch Menu!',
     Caretaking = 'Caretaking',
     Caretaking_desc = 'Work To keep up the ranch!',
@@ -215,5 +223,10 @@ Config.Language = {
     Skin = 'Press "G" to butcher animal',
     AnimalKilled = 'You Butchered The Animal!',
     Inventory = 'Ranch Inventory',
-    Inventory_desc = 'Your ranchs inventory, anything you store here will be safe!'
+    Inventory_desc = 'Your ranchs inventory, anything you store here will be safe!',
+    SteamName = "Steam Name",
+    ServId = 'Server ID',
+    PGroup = 'Player Group',
+    OwnerSet = 'Owner Set'
+
 }

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -11,6 +11,7 @@ shared_scripts {
 
 server_scripts {
     'server/server.lua',
+    '@oxmysql/lib/MySQL.lua',
 }
 
 client_scripts {
@@ -32,4 +33,4 @@ dependency {
 }
 
 
-version '1.0.1'
+version '1.0.2'


### PR DESCRIPTION
- Check if player owns ranch API added
- Now set admins in the config via steam id instead of using user database
- Now instead of having to manually go find the character static id to give someone a ranch, a menu will show up displaying the names of every player online and thier character static id. You can then choose who to give the ranch too. (Credit to vorp admin for the logic)
- Version Bump