### PR TITLE
Qol changes

### DIFF
--- a/client/chores.lua
+++ b/client/chores.lua
@@ -1,36 +1,52 @@
+----- Hammertime Minigame Config ------------
+local hammertimecfg = {
+    focus = true, -- Should minigame take nui focus (required)
+    cursor = true, -- Should minigame have cursor  (required)
+    nails = 7, -- How many nails to be hammered
+    type = 'dark-wood' -- What color wood to display (light-wood, medium-wood, dark-wood)
+}
+
 ---- Chore Setup ----
 RegisterNetEvent('bcc-ranch:ShovelHay', function(chore)
-    local chorecoords,choreanim,incamount,animtime
+    local chorecoords,choreanim,incamount,animtime,minigame,minigamecfg
 
     if chore == 'shovelhay' then
         chorecoords = Haycoords
         choreanim = joaat("WORLD_HUMAN_FARMER_RAKE")
         incamount = Config.ChoreConfig.HayChore.ConditionIncrease
         animtime = Config.ChoreConfig.HayChore.AnimTime
+        minigame = 'skillcheck'
+        minigamecfg = Config.ChoreMinigameConfig
     elseif chore == 'wateranimals' then
         chorecoords = WaterAnimalCoords
         choreanim = joaat('WORLD_HUMAN_BUCKET_POUR_LOW')
         incamount = Config.ChoreConfig.WaterAnimals.ConditionIncrease
         animtime = Config.ChoreConfig.WaterAnimals.AnimTime
+        minigame = 'skillcheck'
+        minigamecfg = Config.ChoreMinigameConfig
     elseif chore == 'repairfeedtrough' then
         chorecoords = RepairTroughCoords
         choreanim = joaat('PROP_HUMAN_REPAIR_WAGON_WHEEL_ON_SMALL') --credit syn_construction for anim(just where I found it at lol)
         incamount = Config.ChoreConfig.RepairFeedTrough.ConditionIncrease
         animtime = Config.ChoreConfig.RepairFeedTrough.AnimTime
+        minigame = 'hammertime'
+        minigamecfg = hammertimecfg
     elseif chore == 'scooppoop' then
         chorecoords = ScoopPoopCoords
         choreanim = joaat('WORLD_HUMAN_PITCH_HAY_SCOOP')
         incamount = Config.ChoreConfig.ShovelPoop.ConditionIncrease
         animtime = Config.ChoreConfig.ShovelPoop.AnimTime
+        minigame = 'skillcheck'
+        minigamecfg = Config.ChoreMinigameConfig
     end
 
     InMission = true
     VORPcore.NotifyRightTip(_U("GoToChoreLocation"), 4000)
     TriggerEvent('bcc-ranch:ChoreDeadCheck')
     
-    VORPutils.Gps:SetGps(chorecoords.x, chorecoords.y, chorecoords.z)
+    BccUtils.Misc.SetGps(chorecoords.x, chorecoords.y, chorecoords.z)
     while true do
-        Wait(10)
+        Wait(5)
         if PlayerDead then break end
         local plc = GetEntityCoords(PlayerPedId())
         local dist = GetDistanceBetweenCoords(plc.x, plc.y, plc.z, chorecoords.x, chorecoords.y, chorecoords.z, true)
@@ -41,27 +57,42 @@ RegisterNetEvent('bcc-ranch:ShovelHay', function(chore)
             if IsControlJustReleased(0, 0x760A9C6F) then
                 ClearGpsMultiRoute()
                 if Config.ChoreMinigames then
-                    MiniGame.Start('skillcheck', Config.ChoreMinigameConfig, function(result)
-                        if result.passed then
-                            TaskStartScenarioInPlace(PlayerPedId(), choreanim, animtime, true, false, false, false)
-                            Wait(animtime)
-                            ClearPedTasksImmediately(PlayerPedId())
-                            if PlayerDead then
+                    MiniGame.Start(minigame, minigamecfg, function(result)
+                        if minigame == 'hammertime' then
+                            if result.result then
+                                BccUtils.Ped.ScenarioInPlace(PlayerPedId(), choreanim, animtime)
+                                if PlayerDead then
+                                    InMission = false
+                                    VORPcore.NotifyRightTip(_U("PlayerDead"), 4000) return
+                                end
+                                VORPcore.NotifyRightTip(_U("ChoreComplete"), 4000)
+                                TriggerServerEvent('bcc-ranch:RanchConditionIncrease', incamount, RanchId)
                                 InMission = false
-                                VORPcore.NotifyRightTip(_U("PlayerDead"), 4000) return
+                            else
+                                InMission = false
+                                VORPcore.NotifyRightTip(_U("Failed"), 4000) return
                             end
-                            VORPcore.NotifyRightTip(_U("ChoreComplete"), 4000)
-                            TriggerServerEvent('bcc-ranch:RanchConditionIncrease', incamount, RanchId)
-                            InMission = false
                         else
-                            InMission = false
-                            VORPcore.NotifyRightTip(_U("Failed"), 4000) return
+                            if result.passed then
+                                if chore == 'scooppoop' then
+                                    TriggerServerEvent('bcc-ranch:AddItem', Config.ChoreConfig.ShovelPoop.RecievedItem, Config.ChoreConfig.ShovelPoop.RecievedAmount)
+                                end
+                                BccUtils.Ped.ScenarioInPlace(PlayerPedId(), choreanim, animtime)
+                                if PlayerDead then
+                                    InMission = false
+                                    VORPcore.NotifyRightTip(_U("PlayerDead"), 4000) return
+                                end
+                                VORPcore.NotifyRightTip(_U("ChoreComplete"), 4000)
+                                TriggerServerEvent('bcc-ranch:RanchConditionIncrease', incamount, RanchId)
+                                InMission = false
+                            else
+                                InMission = false
+                                VORPcore.NotifyRightTip(_U("Failed"), 4000) return
+                            end
                         end
                     end) break
                 else
-                    TaskStartScenarioInPlace(PlayerPedId(), choreanim, animtime, true, false, false, false)
-                    Wait(animtime)
-                    ClearPedTasksImmediately(PlayerPedId())
+                    BccUtils.Ped.ScenarioInPlace(PlayerPedId(), choreanim, animtime)
                     if PlayerDead then
                         InMission = false
                         VORPcore.NotifyRightTip(_U("PlayerDead"), 4000) break

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -14,17 +14,6 @@ end)
 BccUtils = exports['bcc-utils'].initiate()
 MiniGame = exports['bcc-minigames'].initiate()
 
-------- Load Model -------
-function modelload(model)
-  RequestModel(model)
-  if not HasModelLoaded(model) then
-    RequestModel(model)
-  end
-  while not HasModelLoaded(model) do
-    Wait(100)
-  end
-end
-
 ----- Setting RelationShip ----
 function relationshipsetup(ped, relint) --ped and player relationship setter, rail int is 1-5 1 being friend 5 being hate
   SetRelationshipBetweenGroups(relint, GetPedRelationshipGroupHash(ped), joaat('PLAYER'))

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,6 @@
 Config = {}
 
-Config.Debug = true --false on live server
+Config.Debug = false --false on live server
 
 -- Set Language (Current Languages: "en_lang")
 Config.defaultlang = "en_lang"
@@ -64,6 +64,8 @@ Config.ChoreConfig = {
         ConditionIncrease = 20,
     },
     ShovelPoop = {
+        RecievedItem = 'poop', --You will recieve this item upon completion of this chore(database name of the item)
+        RecievedAmount = 2, --this is the amount of the item you will recieve (set 0 if you do not want this feature)
         AnimTime = 5000,
         ConditionIncrease = 5,
     },
@@ -71,6 +73,8 @@ Config.ChoreConfig = {
 
 --Main Ranch Setup
 Config.RanchSetup = {
+    WolfAttacks = true, --if true there is a chance 2 wolves will spawn while herding or selling animals and attack you!(50 50 chance)
+    AnimalsWalkOnly = true, --If true animals that you herd or sell will only be able to walk, if false they can run. (Cows will not run no matter what)
     RanchCondDecrease = 1800000, --This is how often the ranches condition will decrease over time
     InvLimit = 200, --Maximum inventory space the ranch will have
     InvName = 'Ranch Inventory', --Name of the inventory
@@ -163,7 +167,7 @@ Config.SaleLocations = {
     }, --to add more just copy this table paste and change what you want
     {
         LocationName = 'Sale Area 2',
-        Coords = {x = -239.39, y = 710.95, z = 113.29},
+        Coords = {x = -767.63, y = -1389.87, z = 43.27},
     },
 }
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -36,4 +36,4 @@ dependency {
 }
 
 
-version '1.0.5'
+version '1.0.6'

--- a/server/server.lua
+++ b/server/server.lua
@@ -28,6 +28,12 @@ RegisterServerEvent('bcc-ranch:OpenInv', function(ranchid)
     VORPInv.OpenInv(_source, 'Player_' .. ranchid .. '_bcc-ranchinv')
 end)
 
+-------- Adding Items ----------
+RegisterServerEvent('bcc-ranch:AddItem', function(item, amount)
+    local _source = source
+    VORPInv.addItem(_source, item, amount)
+end)
+
 ---------------------- DB AREA ----------------------------------
 -------- Creates DB ----------
 CreateThread(function()


### PR DESCRIPTION
- Repair Feed Trough chore now uses a new minigame!
- Utilizing more of bcc-utils features!
- When you sell an animal it will now choose the closest sell location to the player instead of picking a random one!
- Optional (set in config) 50% chance to have 2 wolves spawn during an animal sale and attack the player!
- Config option to allow or disable animals being able to run when being herded or sold! (Cows will always walk no matter what sadly)
- Option in the config to have the shoveling poop chore give you a poop item! Could be used in a crafting recipe to make fertilizer for farming scripts like bcc-farming!
- Version Bump