### PR TITLE
feat: add check on set animal coords if they are inside the range of the ranch

### DIFF
--- a/client/menusetup/Animals.lua
+++ b/client/menusetup/Animals.lua
@@ -302,6 +302,11 @@ RegisterNetEvent('bcc-ranch:OwnedAnimalManagerMenu', function(animalCond, animal
                 end,
                 ['setanimalcoords'] = function()
                     local pl = GetEntityCoords(PlayerPedId())
+                    -- check if player tries to set the takeout spots for the animas outside the ranch
+                    if GetDistanceBetweenCoords(pl.x, pl.y, pl.z, tonumber(RanchCoords.x), tonumber(RanchCoords.y), tonumber(RanchCoords.z), true) > tonumber(RanchRadius) then
+                        VORPcore.NotifyRightTip(_U("TooFarFromRanch"), 4000)
+                        return
+                    end
                     local setAnimalSelected = {
                         ['pigs'] = function()
                             TriggerServerEvent("bcc-ranch:AnimalLocationDbInserts", pl, RanchId, 'pigcoords')


### PR DESCRIPTION
Currently, players can set their animal locations anywhere, also outside their ranch. Therefore, players could set them e.g. directly to the herding location and skip the time needed to guard the animals to that location. 

Therefore, I would propose a change where the animal locations have to be inside the ranches range. 