### PR TITLE
feat: cow milking animation is now playing while the minigame is active and not afterwards for a given time

### DIFF
--- a/client/AnimalManager/HarvestingByproducts.lua
+++ b/client/AnimalManager/HarvestingByproducts.lua
@@ -125,11 +125,10 @@ RegisterNetEvent('bcc-ranch:MilkCows', function()
     end
 
     if Config.ChoreMinigames then
+        playAnim('script_rc@rch1@ig@ig_1_milkingthecow', 'milkingloop_john', -1) 
+        VORPcore.NotifyRightTip(_U("milkingCow"), 4000)
         MiniGame.Start('cowmilker', Config.MilkingMinigameConfig, function(result)
             if result.collected >= Config.RanchSetup.RanchAnimalSetup.Cows.AmountToCollect then
-                VORPcore.NotifyRightTip(_U("milkingCow"), 4000)
-                playAnim('script_rc@rch1@ig@ig_1_milkingthecow', 'milkingloop_john', 15000)
-                Wait(16500)
                 VORPcore.NotifyRightTip(_U("cowMilked"), 4000)
                 TriggerServerEvent('bcc-ranch:AddItem', Config.RanchSetup.RanchAnimalSetup.Cows.MilkingItem,
                     Config.RanchSetup.RanchAnimalSetup.Cows.MilkingItemAmount)
@@ -140,6 +139,7 @@ RegisterNetEvent('bcc-ranch:MilkCows', function()
                 DeletePed(createdPed)
                 VORPcore.NotifyRightTip(_U("Failed"), 4000)
             end
+            StopAnimTask(PlayerPedId(), 'script_rc@rch1@ig@ig_1_milkingthecow', 'milkingloop_john', 1.0)
         end)
     else
         VORPcore.NotifyRightTip(_U("milkingCow"), 4000)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -52,5 +52,12 @@ function playAnim(animDict, animName, time) --function to play an animation
   while not HasAnimDictLoaded(animDict) do
     Wait(100)
   end
-  TaskPlayAnim(PlayerPedId(), animDict, animName, 1.0, 1.0, time, 16, 0, true, 0, false, 0, false)
+  
+  local flag = 16
+  -- if time is -1 then play the animation in an infinite loop which is not possible with flag 16 but with 1
+  -- if time is -1 the caller has to deal with ending the animation by themselve
+  if time == -1 then
+    flag = 1
+  end
+  TaskPlayAnim(PlayerPedId(), animDict, animName, 1.0, 1.0, time, flag, 0, true, 0, false, 0, false)
 end


### PR DESCRIPTION
The cow milking animation will be played during the minigame time. 

Currently, the animation is played after the minigame is finished for 16500 ticks. During the minigame phase, where the player is actually milking the cow via the minigame, the player just stands beside the cow and don't do anything.

So I propose this change, where the animation is played during the minigame time. The animation is now canceled after the minigame result is received, which should make it also automatically dynamically working with the configurable minigame duration in the config.

I also had to change the playAnim so that it is working correctly with looping (infinite) animations. 