### PR TITLE
fix: fix animal sell by handing over animal conditions

### DIFF
--- a/client/menusetup/Animals.lua
+++ b/client/menusetup/Animals.lua
@@ -350,12 +350,10 @@ RegisterNetEvent('bcc-ranch:OwnedAnimalManagerMenu', function(animalCond, animal
                             if Pigcoords and Pigcoords ~= 'none' then
                                 if CanSell then
                                     MenuData.CloseAll()
-                                    SellAnimals('pigs')
+                                    SellAnimals('pigs', animalCond)
                                 else
                                     VORPcore.NotifyRightTip(_U("AnimalsOut"), 4000)
                                 end
-                                MenuData.CloseAll()
-                                SellAnimals('pigs', animalCond)
                             else
                                 VORPcore.NotifyRightTip(_U("NoLocationSet"), 4000)
                             end
@@ -364,7 +362,7 @@ RegisterNetEvent('bcc-ranch:OwnedAnimalManagerMenu', function(animalCond, animal
                             if Goatcoords and Goatcoords ~= 'none' then
                                 if CanSell then
                                     MenuData.CloseAll()
-                                    SellAnimals('goats')
+                                    SellAnimals('goats', animalCond)
                                 else
                                     VORPcore.NotifyRightTip(_U("AnimalsOut"), 4000)
                                 end
@@ -376,7 +374,7 @@ RegisterNetEvent('bcc-ranch:OwnedAnimalManagerMenu', function(animalCond, animal
                             if Chickencoords and Chickencoords ~= 'none' then
                                 if CanSell then
                                     MenuData.CloseAll()
-                                    SellAnimals('chickens')
+                                    SellAnimals('chickens', animalCond)
                                 else
                                     VORPcore.NotifyRightTip(_U("AnimalsOut"), 4000)
                                 end
@@ -388,7 +386,7 @@ RegisterNetEvent('bcc-ranch:OwnedAnimalManagerMenu', function(animalCond, animal
                             if Cowcoords and Cowcoords ~= 'none' then
                                 if CanSell then
                                     MenuData.CloseAll()
-                                    SellAnimals('cows')
+                                    SellAnimals('cows', animalCond)
                                 else
                                     VORPcore.NotifyRightTip(_U("AnimalsOut"), 4000)
                                 end


### PR DESCRIPTION
As described in #56 there is currently an issue where the SellAnimals functions will return an error as it tries to read a nil value because the animalCond variable is not passed at all.


Closes #56 
